### PR TITLE
add disfavored overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Swift syntax sugar for modifying properties
 ## Usage
 ### Class Type
 ```swift
-let label: UILabel = UILabel()^ // Must specify type
+let label: UILabel = UILabel()^ // Specify type
     .text("Hello")
     .textColor(.red)
     .backgroundColor(.blue)
@@ -13,6 +13,18 @@ let label: UILabel = UILabel()^ // Must specify type
         $0.sizeToFit()
     }
     .text("Hello2")
+
+/* or */
+
+let label = UILabel()^
+    .text("Hello")
+    .textColor(.red)
+    .backgroundColor(.blue)
+    .modify {
+        $0.sizeToFit()
+    }
+    .text("Hello2")
+    .value // Append `value` at the end
 
 /* or */
 
@@ -44,13 +56,24 @@ Make a copy and assign a value.
 The original `item` is not modified.
 ```swift
 let item = Item()
-let new: Item = item^　// Must specify type
+let new: Item = item^　// Specify type
     .number(2)
     .number(1)
     .text("2")
     .modify {
         $0.set(text: "1")
     }
+
+/* or */
+
+let new = item^
+    .number(2)
+    .number(1)
+    .text("2")
+    .modify {
+        $0.set(text: "1")
+    }
+    .value // Append `value` at the end
 
 print(item) // Item(text: "", number: 0)
 print(new) // Item(text: "1", number: 1)

--- a/Sources/Modify/Modify.swift
+++ b/Sources/Modify/Modify.swift
@@ -2,15 +2,19 @@ import Foundation
 
 @dynamicMemberLookup
 public struct DynamicMemberWrap<T> {
-    private var value: T
+    private var _value: T
+
+    public var value: T {
+        _value
+    }
 
     public init(_ value: T) {
-        self.value = value
+        self._value = value
     }
 
     public subscript<U>(dynamicMember keyPath: WritableKeyPath<T, U>) -> ((U) -> DynamicMemberWrap<T>) {
         { val in
-            var value = self.value
+            var value = self._value
             value[keyPath: keyPath] = val
             return DynamicMemberWrap(value)
         }
@@ -19,21 +23,21 @@ public struct DynamicMemberWrap<T> {
     @_disfavoredOverload
     public subscript<U>(dynamicMember keyPath: WritableKeyPath<T, U>) -> ((U) -> T) {
         { val in
-            var value = self.value
+            var value = self._value
             value[keyPath: keyPath] = val
             return value
         }
     }
 
     public func modify(_ block: ((inout T) -> Void)) -> DynamicMemberWrap<T> {
-        var value = self.value
+        var value = self._value
         block(&value)
         return DynamicMemberWrap(value)
     }
 
     @_disfavoredOverload
     public func modify(_ block: ((inout T) -> Void)) -> T {
-        var value = self.value
+        var value = self._value
         block(&value)
         return value
     }

--- a/Sources/Modify/Modify.swift
+++ b/Sources/Modify/Modify.swift
@@ -16,6 +16,7 @@ public struct DynamicMemberWrap<T> {
         }
     }
 
+    @_disfavoredOverload
     public subscript<U>(dynamicMember keyPath: WritableKeyPath<T, U>) -> ((U) -> T) {
         { val in
             var value = self.value
@@ -30,6 +31,7 @@ public struct DynamicMemberWrap<T> {
         return DynamicMemberWrap(value)
     }
 
+    @_disfavoredOverload
     public func modify(_ block: ((inout T) -> Void)) -> T {
         var value = self.value
         block(&value)

--- a/Tests/ModifyTests/ModifyTests.swift
+++ b/Tests/ModifyTests/ModifyTests.swift
@@ -54,6 +54,23 @@ final class ModifyTests: XCTestCase {
             }
 
         XCTAssertEqual(item.text, "1")
+
+        var text = CGRect.zero
+        text^=
+            .origin(.init(x: 89, y: 89))
+
+        var origin = CGPoint.zero
+        origin^=
+            .x(99)
+            .y(.pi)
+
+        text^=
+            .origin(origin)
+
+        print(text^
+            .origin(.zero)
+            .size(.zero)
+        )
     }
 }
 


### PR DESCRIPTION
In addition to the previous writing style, allow a method of writing that omits the specification of the type

```swift
let label = UILabel()^
    .text("Hello")
    .textColor(.red)
    .backgroundColor(.blue)
    .modify {
        $0.sizeToFit()
    }
    .text("Hello2")
    .value // Append `value` at the end

```