### PR TITLE
callAsFunction for `modify` closure

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,26 @@ item^=
 
 print(item) // Item(text: "1", number: 1)
 ```
+
+### Closure
+
+```swift
+let button: UIButton = UIButton()^ {
+    $0.setTitle("normal", for: .normal)
+    $0.setTitle("disabled", for: .disabled)
+}
+.backgroundColor(.red)
+.clipToBounds(true)
+.isEnabled(true)
+
+/* or */
+
+let button: UIButton = UIButton()^ 
+    .modify {
+        $0.setTitle("normal", for: .normal)
+        $0.setTitle("disabled", for: .disabled)
+    }
+    .backgroundColor(.red)
+    .clipToBounds(true)
+    .isEnabled(true)
+```

--- a/Sources/Modify/Modify.swift
+++ b/Sources/Modify/Modify.swift
@@ -12,6 +12,15 @@ public struct DynamicMemberWrap<T> {
         self._value = value
     }
 
+    public func callAsFunction(_ block: ((inout T) -> Void)) -> DynamicMemberWrap<T> {
+        modify(block)
+    }
+
+    @_disfavoredOverload
+    public func callAsFunction(_ block: ((inout T) -> Void)) -> T {
+        modify(block)
+    }
+
     public subscript<U>(dynamicMember keyPath: WritableKeyPath<T, U>) -> ((U) -> DynamicMemberWrap<T>) {
         { val in
             var value = self._value

--- a/Tests/ModifyTests/ModifyTests.swift
+++ b/Tests/ModifyTests/ModifyTests.swift
@@ -19,7 +19,6 @@ final class ModifyTests: XCTestCase {
             .text("2")
             .text("1")
 
-
         XCTAssertEqual(new.text, "1")
         XCTAssertEqual(new.number, 1)
     }
@@ -54,6 +53,15 @@ final class ModifyTests: XCTestCase {
             }
 
         XCTAssertEqual(item.text, "1")
+    }
+
+    func testCallAsFunction() throws {
+        let item = Item()
+        let new: Item = item^ {
+            $0.set(text: "1")
+        }
+
+        XCTAssertEqual(new.text, "1")
     }
 }
 


### PR DESCRIPTION
```swift
let button: UIButton = UIButton()^ 
    .modify {
        $0.setTitle("normal", for: .normal)
        $0.setTitle("disabled", for: .disabled)
    }
    .backgroundColor(.red)
    .clipToBounds(true)
    .isEnabled(true)
```

↓

```swift
let button: UIButton = UIButton()^ {
    $0.setTitle("normal", for: .normal)
    $0.setTitle("disabled", for: .disabled)
}
.backgroundColor(.red)
.clipToBounds(true)
.isEnabled(true)
```