### PR TITLE
add `callAsFunction` method to `AssignmentDynamicMemberWrap` 

### DIFF
--- a/Sources/Modify/Modify.swift
+++ b/Sources/Modify/Modify.swift
@@ -60,6 +60,11 @@ public struct AssignmentDynamicMemberWrap<T> {
         self.pointer = withUnsafeMutablePointer(to: &value) { $0 }
     }
 
+    @discardableResult
+    public func callAsFunction(_ block: ((inout T) -> Void)) -> AssignmentDynamicMemberWrap<T> {
+        modify(block)
+    }
+
     public subscript<U>(dynamicMember keyPath: WritableKeyPath<T, U>) -> DiscardableResultClosure<U, AssignmentDynamicMemberWrap<T>> {
         DiscardableResultClosure { val in
             pointer.pointee[keyPath: keyPath] = val
@@ -81,6 +86,11 @@ public struct AssignmentReferenceDynamicMemberWrap<T> where T: AnyObject {
 
     public init(_ value: T) {
         self.value = value
+    }
+
+    @discardableResult
+    public func callAsFunction(_ block: ((T) -> Void)) -> AssignmentReferenceDynamicMemberWrap<T> {
+        modify(block)
     }
 
     public subscript<U>(dynamicMember keyPath: WritableKeyPath<T, U>) -> DiscardableResultClosure<U, AssignmentReferenceDynamicMemberWrap<T>> {

--- a/Tests/ModifyTests/ModifyTests.swift
+++ b/Tests/ModifyTests/ModifyTests.swift
@@ -63,5 +63,14 @@ final class ModifyTests: XCTestCase {
 
         XCTAssertEqual(new.text, "1")
     }
+
+    func testAssignCallAsFunction() throws {
+        var item = Item()
+        item^= {
+            $0.set(text: "1")
+        }
+
+        XCTAssertEqual(item.text, "1")
+    }
 }
 


### PR DESCRIPTION
add `callAsFunction` method to `AssignmentDynamicMemberWrap` and `AssignmentReferenceDynamicMemberWrap`

```swift
var item = Item() // var
item^=
    .modify {
        $0.set(text: "1")
    }
```

↓

```swift
var item = Item() // var
item^= {
    $0.set(text: "1")
}
```